### PR TITLE
Fix filter registration for filter_robots function to ensure correct …

### DIFF
--- a/includes/class-ds-more-privacy-hooks.php
+++ b/includes/class-ds-more-privacy-hooks.php
@@ -60,7 +60,7 @@ class Ds_More_Privacy_Hooks {
 		add_action( 'login_form', array( $this, 'login_message' ) );
 		add_filter( 'privacy_on_link_title', array( $this, 'header_title_link' ) );
 		add_filter( 'privacy_on_link_text', array( $this, 'header_title_link' ) );
-		add_filter( 'robots_txt', array( $this, 'filter_robots' ) );
+		add_filter('robots_txt', array($this, 'filter_robots'), 10, 2);
 
 		// fixes noindex meta.
 		add_action( 'wp_head', array( $this, 'noindex' ), 0 );


### PR DESCRIPTION
when accessing sitename.com/robots.txt, WordPress throws a Fatal Error. 

Fatal error: Uncaught ArgumentCountError: Too few arguments to function Ds_More_Privacy_Hooks::filter_robots(), 1 passed in /wp-includes/class-wp-hook.php on line 326 and exactly 2 expected in /wp-content/plugins/more-privacy-options/includes/class-ds-more-privacy-hooks.php:349